### PR TITLE
Add -caption and -fontsize

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ ytgif -start 74.8 -finish 75.8 -nosubs -gifsicle \
 -nosubs:        do not include subtitles in the output even if they're available
 -sub-lang lang: sub language to choose
 -autosubs:      prefer youtube's auto-generated subtitles
+-caption text:  use a caption for the entire gif instead of subtitles
+-fontsize:      the font size for the caption. Defaults to 30 if caption set,
+                otherwise to whatever ffmpeg defaults it to
 ```
 
 ## PREREQUISITES
@@ -49,22 +52,29 @@ After installing the prerequisites, copy `ytgif.bash` to somewhere on your `$PAT
 
 Download the "I can't believe you've done this" clip, and turn the whole thing into "donethis.gif"
 
-    ytgif "https://www.youtube.com/watch?v=wKbU8B-QVZk" "donethis.gif"
+    ytgif "https://www.youtube.com/watch?v=wKbU8B-QVZk" donethis.gif
 
 Download the "don't call me shirley" clip from youtube, cut from 1:02 to 1:10.9, lower the fps to 10, and save it as airplane.gif:
 
     ytgif -start 1:02 -finish 1:10.9 -fps 10 \
-        "https://www.youtube.com/watch?v=ixljWVyPby0" "airplane.gif"
+      "https://www.youtube.com/watch?v=ixljWVyPby0" airplane.gif
 
 Download a bit of a linear algebra lecture, and subtitle it in spanish:
 
     ytgif -sub-lang es -start 26:54 -finish 27:02 \
-        "https://www.youtube.com/watch?v=QVKj3LADCnA" "strang.gif"
+      "https://www.youtube.com/watch?v=QVKj3LADCnA" strang.gif
 
 Create a tiny rickroll gif, optimize it, and don't include subtitles:
 
     ytgif -gifsicle -scale 30 -start 0.5 -finish 3 -nosubs \
-       "https://www.youtube.com/watch?v=dQw4w9WgXcQ" "rickroll.gif"
+     "https://www.youtube.com/watch?v=dQw4w9WgXcQ" rickroll.gif
+
+Create a gif of Gob Bluth, and manually set the caption to "I've made a huge
+mistake":
+
+    ytgif -v -start 13 -finish 17 -gifsicle -fps 10 \
+     -fontsize 40 -caption "I've made a huge mistake" \
+     "https://www.youtube.com/watch?v=GwQW3KW3DCc" mistake.gif
 
 ## NOTES
 

--- a/ytgif.bash
+++ b/ytgif.bash
@@ -43,27 +43,34 @@ EXAMPLES
 
 Download the "I can't believe you've done this" clip, and turn the whole thing into "donethis.gif"
 
-  ytgif "https://www.youtube.com/watch?v=wKbU8B-QVZk" "donethis.gif"
+  ytgif "https://www.youtube.com/watch?v=wKbU8B-QVZk" donethis.gif
 
 Download the "don't call me shirley" clip from youtube, cut from 1:02 to 1:10.9 lower the fps to 10, and save it as airplane.gif:
 
   ytgif -start 1:02 -finish 1:10.9 -fps 10 \
-    "https://www.youtube.com/watch?v=ixljWVyPby0" "airplane.gif"
+    "https://www.youtube.com/watch?v=ixljWVyPby0" airplane.gif
 
 Download a bit of a linear algebra lecture, and subtitle it in spanish:
 
   ytgif -sub-lang es -start 26:54 -finish 27:02 \
-    "https://www.youtube.com/watch?v=QVKj3LADCnA" "strang.gif"
+    "https://www.youtube.com/watch?v=QVKj3LADCnA" strang.gif
 
 Create a tiny rickroll gif, optimize it, and don't include subtitles:
 
   ytgif -gifsicle -scale 30 -start 0.5 -finish 3 -nosubs \
-    "https://www.youtube.com/watch?v=dQw4w9WgXcQ" "rickroll.gif"
+    "https://www.youtube.com/watch?v=dQw4w9WgXcQ" rickroll.gif
 
 Create a gif of owen wilson saying "wow":
 
   ytgif -start 74.8 -finish 75.8 -nosubs -gifsicle \
     "https://www.youtube.com/watch?v=KlLMlJ2tDkg&t=50s" wow.gif
+
+Create a gif of Gob Bluth, and manually set the caption to "I've made a huge
+mistake":
+
+  ytgif -v -start 13 -finish 17 -gifsicle -fps 10 \
+    -fontsize 40 -caption "I've made a huge mistake" \
+    "https://www.youtube.com/watch?v=GwQW3KW3DCc" mistake.gif
 
 NOTES
 


### PR DESCRIPTION
- Add `-caption` to set a single-line caption for the entire duration of the gif
- Add `-fontsize`, which sets the fontsize for the caption or the subtitles, whichever is used
- Document this feature and give an example
- Expand the `complex_filter`s so they are a tiny bit more readable (still not very readable, try to come up with more better formatting)
- Log the bash version if we tell somebody they can't use this script

relates to #2